### PR TITLE
Updates `debug` package to address security alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "body-parser",
-  "description": "Node.js body parsing middleware",
+  "description": "Node.js body parsing middleware.",
   "version": "1.20.2",
   "contributors": [
     "Douglas Christopher Wilson <doug@somethingdoug.com>",
@@ -11,7 +11,7 @@
   "dependencies": {
     "bytes": "3.1.2",
     "content-type": "~1.0.5",
-    "debug": "2.6.9",
+    "debug": "3.2.7",
     "depd": "2.0.0",
     "destroy": "1.2.0",
     "http-errors": "2.0.0",


### PR DESCRIPTION
Addresses the [VDB-217665](https://security.snyk.io/vuln/SNYK-DEBIAN11-NODEDEBUG-3231713) vulnerability on versions matching <3.1.0-1.

Verified that all of the interfaces used in the body-parser code are still supported. Also verified by running the tests and enabling the debug messages via:

```
DEBUG=* npm run test
```

Verified the tests pass locally on all the LTF versions but depending on the GH Action to run against all node versions supported to verify it continues to work for them.